### PR TITLE
feat: expose WeChat comment options in MCP publish tool

### DIFF
--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -2,6 +2,23 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { LIST_THEMES_SCHEMA, REGISTER_THEME_SCHEMA, REMOVE_THEME_SCHEMA } from "./theme.js";
 import { PUBLISH_ARTICLE_SCHEMA, publishArticle } from "./publish.js";
+
+function parseCommentFlag(value: unknown): 0 | 1 | undefined {
+    return value === 0 ? 0 : value === 1 ? 1 : undefined;
+}
+
+export function parsePublishArticleArgs(args: Record<string, unknown>, clientVersion: string) {
+    return {
+        content: String(args.content || ""),
+        contentUrl: String(args.content_url || ""),
+        file: String(args.file || ""),
+        themeId: String(args.theme_id || ""),
+        appId: String(args.app_id || ""),
+        clientVersion,
+        needOpenComment: parseCommentFlag(args.need_open_comment),
+        onlyFansCanComment: parseCommentFlag(args.only_fans_can_comment),
+    };
+}
 import pkg from "../package.json" with { type: "json" };
 import { buildMcpResponse, globalStates } from "./utils.js";
 import { addTheme, listThemes, removeTheme } from "@wenyan-md/core/wrapper";
@@ -45,13 +62,17 @@ export function createServer(): Server {
                 if (globalStates.isClientMode && !globalStates.serverUrl) {
                     throw new Error("Missing server URL. Usage: --server <server_url>");
                 }
-                const args = request.params.arguments || {};
-                const content = String(args.content || "");
-                const contentUrl = String(args.content_url || "");
-                const file = String(args.file || "");
-                const themeId = String(args.theme_id || "");
-                const appId = String(args.app_id || "");
-                return await publishArticle(contentUrl, file, content, themeId, appId, pkg.version);
+                const args = parsePublishArticleArgs(request.params.arguments || {}, pkg.version);
+                return await publishArticle(
+                    args.contentUrl,
+                    args.file,
+                    args.content,
+                    args.themeId,
+                    args.appId,
+                    args.clientVersion,
+                    args.needOpenComment,
+                    args.onlyFansCanComment,
+                );
             } else if (request.params.name === "list_themes") {
                 const themes = await listThemes();
                 const builtinThemes = themes.filter((theme) => theme.isBuiltin);

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,6 +1,17 @@
 import { renderAndPublish, renderAndPublishToServer } from "@wenyan-md/core/wrapper";
 import { buildMcpResponse, getInputContent, globalStates } from "./utils.js";
 
+export interface PublishArticleInput {
+    contentUrl: string;
+    file: string;
+    content: string;
+    themeId: string;
+    appId?: string;
+    clientVersion?: string;
+    needOpenComment?: 0 | 1;
+    onlyFansCanComment?: 0 | 1;
+}
+
 export const PUBLISH_ARTICLE_SCHEMA = {
     name: "publish_article",
     description: "Format a Markdown article using a selected theme and publish it to '微信公众号'.",
@@ -32,24 +43,60 @@ export const PUBLISH_ARTICLE_SCHEMA = {
                 description:
                     "AppID for the WeChat MP platform ('微信公众号').",
             },
+            need_open_comment: {
+                type: "integer",
+                enum: [0, 1],
+                description:
+                    "Whether to enable comments on the draft. 1 enables comments; 0 disables them.",
+            },
+            only_fans_can_comment: {
+                type: "integer",
+                enum: [0, 1],
+                description:
+                    "Whether only followers can comment. This only takes effect when need_open_comment is 1.",
+            },
         },
     },
 } as const;
 
-export async function publishArticle(contentUrl: string, file: string, content: string, themeId: string, appId?: string, clientVersion?: string) {
-    let mediaId = "";
-    const publishOptions = {
-        file: file ? file : contentUrl,
-        theme: themeId,
+export function buildPublishOptions(input: PublishArticleInput) {
+    return {
+        file: input.file ? input.file : input.contentUrl,
+        theme: input.themeId,
         highlight: "solarized-light",
         macStyle: true,
         footnote: true,
         server: globalStates.serverUrl,
         apiKey: globalStates.apiKey,
-        clientVersion,
+        clientVersion: input.clientVersion,
         disableStdin: true,
-        appId: appId ? appId : undefined,
+        appId: input.appId ? input.appId : undefined,
+        need_open_comment: input.needOpenComment,
+        only_fans_can_comment: input.needOpenComment === 1 ? input.onlyFansCanComment : undefined,
     };
+}
+
+export async function publishArticle(
+    contentUrl: string,
+    file: string,
+    content: string,
+    themeId: string,
+    appId?: string,
+    clientVersion?: string,
+    needOpenComment?: 0 | 1,
+    onlyFansCanComment?: 0 | 1,
+) {
+    let mediaId = "";
+    const publishOptions = buildPublishOptions({
+        contentUrl,
+        file,
+        content,
+        themeId,
+        appId,
+        clientVersion,
+        needOpenComment,
+        onlyFansCanComment,
+    });
     if(globalStates.isClientMode) {
         mediaId = await renderAndPublishToServer(content, publishOptions, getInputContent);
     } else {

--- a/tests/publishCommentOptions.test.ts
+++ b/tests/publishCommentOptions.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PUBLISH_ARTICLE_SCHEMA, buildPublishOptions } from "../src/publish.ts";
+import { parsePublishArticleArgs } from "../src/mcpServer.ts";
+import { globalStates } from "../src/utils.ts";
+
+test("publish_article schema exposes comment flags", () => {
+    const properties = PUBLISH_ARTICLE_SCHEMA.inputSchema.properties;
+
+    assert.equal(properties.need_open_comment.type, "integer");
+    assert.deepEqual(properties.need_open_comment.enum, [0, 1]);
+    assert.equal(properties.only_fans_can_comment.type, "integer");
+    assert.deepEqual(properties.only_fans_can_comment.enum, [0, 1]);
+});
+
+test("buildPublishOptions includes comment flags", () => {
+    globalStates.serverUrl = "http://localhost:3000";
+    globalStates.apiKey = "test-api-key";
+
+    const publishOptions = buildPublishOptions({
+        contentUrl: "./tests/publish.md",
+        file: "",
+        content: "# Hello",
+        themeId: "phycat",
+        appId: "wx123",
+        clientVersion: "2.0.2",
+        needOpenComment: 1,
+        onlyFansCanComment: 1,
+    });
+
+    assert.equal(publishOptions.file, "./tests/publish.md");
+    assert.equal(publishOptions.server, "http://localhost:3000");
+    assert.equal(publishOptions.apiKey, "test-api-key");
+    assert.equal(publishOptions.need_open_comment, 1);
+    assert.equal(publishOptions.only_fans_can_comment, 1);
+});
+
+test("parsePublishArticleArgs preserves comment flags", () => {
+    const parsed = parsePublishArticleArgs(
+        {
+            content: "# Hello",
+            content_url: "https://example.com/post.md",
+            file: "./tests/publish.md",
+            theme_id: "phycat",
+            app_id: "wx123",
+            need_open_comment: 1,
+            only_fans_can_comment: 1,
+        },
+        "2.0.2",
+    );
+
+    assert.equal(parsed.content, "# Hello");
+    assert.equal(parsed.contentUrl, "https://example.com/post.md");
+    assert.equal(parsed.file, "./tests/publish.md");
+    assert.equal(parsed.themeId, "phycat");
+    assert.equal(parsed.appId, "wx123");
+    assert.equal(parsed.clientVersion, "2.0.2");
+    assert.equal(parsed.needOpenComment, 1);
+    assert.equal(parsed.onlyFansCanComment, 1);
+});
+
+test("parsePublishArticleArgs ignores invalid comment flag values", () => {
+    const parsed = parsePublishArticleArgs(
+        {
+            need_open_comment: "1",
+            only_fans_can_comment: 2,
+        },
+        "2.0.2",
+    );
+
+    assert.equal(parsed.needOpenComment, undefined);
+    assert.equal(parsed.onlyFansCanComment, undefined);
+});
+
+test("buildPublishOptions only keeps follower comment flag when comments are enabled", () => {
+    globalStates.serverUrl = "http://localhost:3000";
+    globalStates.apiKey = "test-api-key";
+
+    const publishOptions = buildPublishOptions({
+        contentUrl: "./tests/publish.md",
+        file: "",
+        content: "# Hello",
+        themeId: "phycat",
+        needOpenComment: 0,
+        onlyFansCanComment: 1,
+    });
+
+    assert.equal(publishOptions.need_open_comment, 0);
+    assert.equal(publishOptions.only_fans_can_comment, undefined);
+});


### PR DESCRIPTION
## Summary
- expose `need_open_comment` and `only_fans_can_comment` in the `publish_article` MCP schema
- parse the new fields from tool arguments and pass them into publish options
- add tests for schema exposure, argument parsing, and comment option normalization

## Test plan
- [x] `node --import tsx --test tests/publishCommentOptions.test.ts`
- [x] `pnpm run typecheck`